### PR TITLE
Remove the apt-get cache after install packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN \
     curl \
     openssh-client \
     unzip \
-    git
+    git && \
+  rm -rf /var/lib/apt/lists/*
 
  ENV GOPATH /go
  ENV PATH /go/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
Remove `rm -rf /var/lib/apt/lists/*` after doing an apt-get update will make the image a little bit more light.