### PR TITLE
Provide a way to skip specific examples

### DIFF
--- a/task
+++ b/task
@@ -19,5 +19,6 @@ export CF_DIAL_TIMEOUT=11
 -randomizeAllSpecs \
 -skipPackage=helpers \
 -slowSpecThreshold=120 \
--nodes="${NODES}"
+-nodes="${NODES}" \
+-skip="${SKIP_REGEXP}"
 

--- a/task.yml
+++ b/task.yml
@@ -17,3 +17,4 @@ run:
 params:
   NODES: 12
   CONFIG_FILE_PATH: integration_config.json
+  SKIP_REGEXP:


### PR DESCRIPTION
It is safe to always send the `skip` flag, because an empty value is ignored.

Signed-off-by: Tushar Singal <tusharsingal@gmail.com>