### PR TITLE
export CF_PLUGIN_HOME to match new cli plugin behavior

### DIFF
--- a/task
+++ b/task
@@ -23,6 +23,8 @@ cd /go/src/github.com/cloudfoundry/cf-acceptance-tests
 
 export CF_DIAL_TIMEOUT=11
 
+export CF_PLUGIN_HOME=$HOME
+
 ./bin/test \
 -keepGoing \
 -randomizeAllSpecs \


### PR DESCRIPTION
Fixes the plugin behavior introduced in `6.28.0`. Documentation should arrive shortly.